### PR TITLE
Build and install under VS 2015

### DIFF
--- a/FixMixedTabs.csproj
+++ b/FixMixedTabs.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/FixMixedTabs.csproj
+++ b/FixMixedTabs.csproj
@@ -12,6 +12,7 @@
     <RootNamespace>FixMixedTabs</RootNamespace>
     <AssemblyName>FixMixedTabs</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition="'$(VisualStudioVersion)' == '14.0'">v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
   </PropertyGroup>

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
   <Identifier Id="FixMixedTabs">
     <Name>Fix Mixed Tabs</Name>
@@ -18,6 +18,9 @@
         <Edition>Pro</Edition>
       </VisualStudio>
       <VisualStudio Version="12.0">
+        <Edition>Pro</Edition>
+      </VisualStudio>
+      <VisualStudio Version="14.0">
         <Edition>Pro</Edition>
       </VisualStudio>
     </SupportedProducts>


### PR DESCRIPTION
Just the manifest fix is needed to compile if you have .net 4.0 installed, but if you don't have it then the csproj fix is needed.

For new release to work under VS2010, it needs to be compiled on a machine with .net 4 and a version of Visual Studio < 2015
